### PR TITLE
feat(ngdoc): ignore site typescript error

### DIFF
--- a/docs/en-us/guides/advance/customize.md
+++ b/docs/en-us/guides/advance/customize.md
@@ -87,6 +87,7 @@ assets/content
 
 ## Step 4
 We need to modify the entry `index.html` and `styles.scss`,change the `app-root` to `dg-root`in `index.html`，import `@docgeni/template/styles/index.scss` to `style.scss`。
+Note: If some typescript errors occurred when `npm run start:docs`, you may need to modify the entry `tsconfig.app.json`, add `"strict": false` to `compilerOptions`.
 
 ```html
 // index.html

--- a/docs/guides/advance/customize.md
+++ b/docs/guides/advance/customize.md
@@ -88,6 +88,7 @@ assets/content
 
 ## 第四步
 需要修改生成站点的入口`index.html`和`styles.scss`,`index.html`中的`app-root`修改为`dg-root`，`style.scss`引入`@docgeni/template/styles/index.scss`。
+注意：如果运行时报typescript相关的错误，则需要修改生成站点的入口的`tsconfig.app.json`文件，在`compilerOptions`里加上`"strict": false`。
 
 ```html
 // index.html


### PR DESCRIPTION
自定义站点生成的tsconfig默认extend了主项目，所以可能会报错，加上`"strict": false`避免报错。