### PR TITLE
feat(core): throw error when child_process is error exit

### DIFF
--- a/packages/core/src/angular/site-builder.ts
+++ b/packages/core/src/angular/site-builder.ts
@@ -243,6 +243,14 @@ export class SiteBuilder {
             child.on('data', data => {
                 this.docgeni.logger.info(data);
             });
+            child.on('exit', (code, signal) => {
+                if (code) {
+                    throw new Error(`Child exited with code ${code}`);
+                }
+                if (signal) {
+                    throw new Error(`Child was killed with signal ${signal}`);
+                }
+            });
         } catch (error) {
             this.docgeni.logger.error(error);
         }


### PR DESCRIPTION
问题：当我使用 gitlab CI 的时候, 发现 build site 的时候即使有错误，也没有 failed
原因：我发现由于 ng 是在 child_process 中执行且没有捕获错误，导致即使有 error ，CI 也不能够正常的捕获。因此加上监听 child_process 错误的方法，使其遇到错误时能够抛出错误， gitlab CI 能够正常捕获并 failed。