### PR TITLE
perf: remove warning messages

### DIFF
--- a/packages/core/src/plugins/built-in-component/built-in-module.ts
+++ b/packages/core/src/plugins/built-in-component/built-in-module.ts
@@ -49,14 +49,12 @@ async function generateNgModuleText(sourceFile: NgSourceFile, components: Compon
 
     return `
 @NgModule({
-${moduleMetadataArgs}
+  ${moduleMetadataArgs}
 })
 export class CustomComponentsModule {
-constructor() {
-    addBuiltInComponents([
-        ${builtInComponentsArgs},
-    ]);
-}
+  constructor() {
+    addBuiltInComponents([${builtInComponentsArgs}]);
+  }
 }
 `;
 }

--- a/packages/template/src/styles/navbar.scss
+++ b/packages/template/src/styles/navbar.scss
@@ -65,7 +65,7 @@
         display: flex;
         align-items: center;
         flex: auto;
-        justify-content: end;
+        justify-content: flex-end;
 
         .search-container {
             flex: auto;


### PR DESCRIPTION
    addBuiltInComponents([
        ${builtInComponentsArgs},
    ]);

生成的自定义站点的时候builtInComponentsArgs没值时，会生成`[,]`,tsconfig里的strict为true时，会报错