### PR TITLE
feat(core): remove default logic that parse components for lib root path, only according to include, and root dir exclude include in config

### DIFF
--- a/.docgenirc.js
+++ b/.docgenirc.js
@@ -44,7 +44,7 @@ module.exports = {
         {
             name: 'alib',
             rootDir: './packages/a-lib',
-            include: ['common'],
+            include: ['./', 'common'],
             exclude: '',
             apiMode: 'compatible',
             categories: [

--- a/packages/a-lib/common/index.ts
+++ b/packages/a-lib/common/index.ts
@@ -1,0 +1,4 @@
+/**
+ * @public
+ */
+export class MyService {}

--- a/packages/a-lib/layout/layout.component.ts
+++ b/packages/a-lib/layout/layout.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, HostBinding, Input, Output, EventEmitter } from '@an
 
 /**
  * Layout container component. it is required that all child components should be placed inside.
+ * @name alibLayout
  */
 @Component({
     selector: 'alib-layout, [alibLayout]',
@@ -30,6 +31,9 @@ export class AlibLayoutComponent implements OnInit {
     ngOnInit(): void {}
 }
 
+/**
+ * @name alibSidebar
+ */
 @Component({
     selector: 'alib-sidebar, [alibSidebar]',
     template: `

--- a/packages/cli/src/schematics/ng-add/init-docgenirc.ts
+++ b/packages/cli/src/schematics/ng-add/init-docgenirc.ts
@@ -7,7 +7,9 @@ import stringifyObject from 'stringify-object';
 
 export class InitDocgenirc {
     private docgenirc: Partial<DocgeniConfig> = {};
+
     constructor(private options: NgAddSchema) {}
+
     private addProperty<T extends keyof DocgeniConfig>(key: T, value: DocgeniConfig[T]) {
         if (!value) {
             return this;
@@ -34,10 +36,29 @@ export class InitDocgenirc {
                 lib: projectName,
                 locales: {}
             });
+            const include: string[] = [];
+            const exclude: string[] = [];
+            const libDirEntry = host.getDir(`${config.sourceRoot}/lib`);
+            const libDirExists = libDirEntry.subdirs.length > 0 || libDirEntry.subfiles.length > 0;
+            if (config.sourceRoot && config.sourceRoot !== config.root) {
+                const sourceDir = config.sourceRoot.replace(config.root + '/', '');
+                // 如果当前 sourceDir 路径和 root 路径不同，说明有 src 文件夹
+                if (sourceDir) {
+                    if (libDirExists) {
+                        include.push(`${sourceDir}/lib`);
+                    } else {
+                        // src 文件夹添加到 include，读取 src 文件夹的组件
+                        include.push(sourceDir);
+                    }
+                }
+            } else {
+                include.push('');
+            }
             libs.push({
                 name: projectName,
                 rootDir: config.root,
-                include: ['src', 'src/lib'],
+                include: include,
+                exclude: exclude,
                 apiMode: 'automatic',
                 categories: []
             });

--- a/packages/cli/src/schematics/testing/test-workspace.ts
+++ b/packages/cli/src/schematics/testing/test-workspace.ts
@@ -3,7 +3,9 @@ import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/te
 
 export class TestWorkspaceFactory {
     private hostTree = new HostTree();
+
     private tree: UnitTestTree;
+
     constructor(public runner: SchematicTestRunner) {}
 
     async create(options?: {
@@ -14,29 +16,27 @@ export class TestWorkspaceFactory {
         strict?: boolean;
         packageManager?: 'npm' | 'yarn' | 'pnpm' | 'cnpm';
     }) {
-        this.tree = await this.runner
-            .runExternalSchematicAsync(
-                '@schematics/angular',
-                'workspace',
-                {
-                    name: 'test-workspace',
-                    version: '14.2.10',
-                    newProjectRoot: 'projects',
-                    ...options
-                },
-                this.hostTree
-            )
-            .toPromise();
+        this.tree = await this.runner.runExternalSchematic(
+            '@schematics/angular',
+            'workspace',
+            {
+                name: 'test-workspace',
+                version: '14.2.10',
+                newProjectRoot: 'projects',
+                ...options
+            },
+            this.hostTree
+        );
         return this.tree;
     }
 
     async addApplication(options: { name: string; [name: string]: any }) {
-        this.tree = await this.runner.runExternalSchematicAsync('@schematics/angular', 'application', options, this.tree).toPromise();
+        this.tree = await this.runner.runExternalSchematic('@schematics/angular', 'application', options, this.tree);
         return this.tree;
     }
 
-    async addLibrary(options: { name: string; [name: string]: any }) {
-        this.tree = await this.runner.runExternalSchematicAsync('@schematics/angular', 'library', options, this.tree).toPromise();
+    async addLibrary(options: { name: string; [key: string]: any }) {
+        this.tree = await this.runner.runExternalSchematic('@schematics/angular', 'library', options, this.tree);
         return this.tree;
     }
 

--- a/packages/cli/test/fixtures/docgenirc/output/.docgenirc-root-equal-source-root.js
+++ b/packages/cli/test/fixtures/docgenirc/output/.docgenirc-root-equal-source-root.js
@@ -20,7 +20,7 @@ module.exports = {
             name: 'lib-test',
             rootDir: 'projects/lib-test',
             include: [
-                'src/lib'
+                ''
             ],
             exclude: [],
             apiMode: 'automatic',

--- a/packages/cli/test/fixtures/docgenirc/output/.docgenirc-without-lib.js
+++ b/packages/cli/test/fixtures/docgenirc/output/.docgenirc-without-lib.js
@@ -20,7 +20,7 @@ module.exports = {
             name: 'lib-test',
             rootDir: 'projects/lib-test',
             include: [
-                'src/lib'
+                'src'
             ],
             exclude: [],
             apiMode: 'automatic',

--- a/packages/core/src/builders/libraries-builder.spec.ts
+++ b/packages/core/src/builders/libraries-builder.spec.ts
@@ -75,7 +75,7 @@ describe('libraries-builder', () => {
         const library = {
             name: 'alib',
             rootDir: libDirPath,
-            include: ['common'],
+            include: ['', 'common'],
             exclude: '',
             categories: [
                 {

--- a/packages/core/src/builders/library-builder.spec.ts
+++ b/packages/core/src/builders/library-builder.spec.ts
@@ -90,7 +90,7 @@ describe('#library-builder', () => {
     const library = normalizeLibConfig({
         name: 'alib',
         rootDir: 'a-lib',
-        include: ['common'],
+        include: ['', 'common'],
         exclude: '',
         categories: [
             {
@@ -168,7 +168,7 @@ describe('#library-builder', () => {
 
         expect(libraryBuilder.components.size).toEqual(0);
         await libraryBuilder.initialize();
-        expect(libraryBuilder.components.size).toEqual(4);
+        expect(libraryBuilder.components.size).toEqual(3);
 
         const barComponent = libraryBuilder.components.get(`${libDirPath}/common/bar`);
         expect(barComponent).toBeTruthy();
@@ -335,7 +335,7 @@ describe('#library-builder', () => {
         const ngParserSpectator = new NgParserSpectator();
 
         const tsconfig = resolve(libDirPath, 'tsconfig.lib.json');
-        context.host.writeFile(tsconfig, '{includes: []}');
+        context.host.writeFile(tsconfig, `{include: []}`);
         const libraryBuilder = new LibraryBuilderImpl(context, library);
         expect(libraryBuilder.getNgDocParser()).toBeFalsy();
         ngParserSpectator.notHaveBeenCalled();


### PR DESCRIPTION
BREAKING CHANGES:
should add '' or './' to include when lib root folder is src folder