### PR TITLE
fix: sync inner search dropdown with signal state

### DIFF
--- a/packages/template/src/services/search.service.spec.ts
+++ b/packages/template/src/services/search.service.spec.ts
@@ -41,27 +41,16 @@ describe('#SearchService', () => {
         input.remove();
     });
 
-    it('should search on input', async () => {
-        input.value = 'Getting';
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        await vi.advanceTimersByTimeAsync(100);
-        expect(spectator.service.result.length).toBe(1);
-        expect(spectator.service.result[0].id).toBe('getting-started');
-        await vi.runAllTimersAsync();
+    it('should search pages by keyword', () => {
+        spectator.service.search('Getting');
+        expect(spectator.service.result().length).toBe(1);
+        expect(spectator.service.result()[0].id).toBe('getting-started');
     });
 
-    it('should not search while IME is composing', async () => {
-        input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
-        input.value = 'jieshao';
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-        await vi.advanceTimersByTimeAsync(100);
-        expect(spectator.service.result.length).toBe(0);
-
-        input.value = '介绍';
-        input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '介绍' }));
-        expect(spectator.service.result.length).toBe(1);
-        expect(spectator.service.result[0].id).toBe('intro');
-        await vi.runAllTimersAsync();
+    it('should return empty result when keyword is blank', () => {
+        spectator.service.search('Getting');
+        spectator.service.search('   ');
+        expect(spectator.service.result()).toEqual([]);
     });
 
     it('should stop IME Enter from reaching bubble listeners', async () => {

--- a/packages/template/src/services/search.service.ts
+++ b/packages/template/src/services/search.service.ts
@@ -1,8 +1,6 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, signal } from '@angular/core';
 import { GlobalContext } from './global-context';
 import { DOCUMENT } from '@angular/common';
-import { fromEvent, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
 
 /** IME "Process" key reported by some browsers while composing CJK text. */
 const IME_PROCESS_KEY_CODE = 229;
@@ -25,9 +23,7 @@ export class SearchService {
 
     private allPages: SearchPageInfo[] = [];
 
-    private destroyed$ = new Subject();
-
-    public result: SearchPageInfo[] = [];
+    readonly result = signal<SearchPageInfo[]>([]);
 
     public get hasAlgolia() {
         return !!(this.global.config.algolia && this.global.config.algolia.apiKey && this.global.config.algolia.indexName);
@@ -39,6 +35,13 @@ export class SearchService {
         } else {
             this.initInnerSearch(searchSelector);
         }
+    }
+
+    public search(keywords: string) {
+        if (!this.allPages.length) {
+            this.generatePages();
+        }
+        this.result.set(this.searchPages(keywords));
     }
 
     private async initAlgolia(searchSelector: string) {
@@ -92,7 +95,6 @@ export class SearchService {
         const searchContainer = this.document.querySelector(searchSelector) as HTMLInputElement | null;
         if (searchContainer) {
             this.bindImeEnterProtection(searchContainer);
-            this.bindInnerSearchInput(searchContainer);
         } else {
             throw new Error('not find search container');
         }
@@ -100,7 +102,7 @@ export class SearchService {
 
     /**
      * Stop third-party/autocomplete Enter handling while IME is confirming text,
-     * and re-emit `input` after composition so the dropdown can open.
+     * and re-emit `input` after composition so Algolia/docsearch can open.
      */
     private bindImeEnterProtection(input: HTMLInputElement) {
         let composing = false;
@@ -139,38 +141,9 @@ export class SearchService {
         );
     }
 
-    private bindInnerSearchInput(searchContainer: HTMLInputElement) {
-        let composing = false;
-
-        fromEvent(searchContainer, 'compositionstart')
-            .pipe(takeUntil(this.destroyed$))
-            .subscribe(() => {
-                composing = true;
-            });
-
-        fromEvent(searchContainer, 'compositionend')
-            .pipe(takeUntil(this.destroyed$))
-            .subscribe(() => {
-                composing = false;
-                this.result = this.searchPages(searchContainer.value);
-            });
-
-        fromEvent(searchContainer, 'input')
-            .pipe(
-                filter(() => !composing),
-                debounceTime(100),
-                map(() => searchContainer.value),
-                distinctUntilChanged(),
-                takeUntil(this.destroyed$),
-            )
-            .subscribe((value) => {
-                this.result = this.searchPages(value);
-            });
-    }
-
     private generatePages() {
         this.allPages = [];
-        this.global.docItems.forEach((docItem) => {
+        (this.global.docItems || []).forEach((docItem) => {
             const path = docItem.path;
             const parentPage = {
                 title: `${docItem.title} ${docItem.subtitle ? docItem.subtitle : ''}`,

--- a/packages/template/src/shared/search/search.component.html
+++ b/packages/template/src/shared/search/search.component.html
@@ -5,6 +5,7 @@
     id="inputSearch"
     [(ngModel)]="searchText"
     [placeholder]="'SEARCH' | dgTranslate"
+    (input)="focus()"
     (blur)="blur()"
     (focus)="focus()"
     (compositionstart)="onCompositionStart()"
@@ -14,19 +15,19 @@
   @if (!searchService.hasAlgolia) {
     <div
       class="search-results-container"
-      [class.is-searching]="hasSearchText && isFocus"
-      [class.result-empty]="searchService.result.length === 0"
+      [class.is-searching]="hasSearchText() && isFocus()"
+      [class.result-empty]="searchService.result().length === 0"
       (mousedown)="$event.preventDefault()"
     >
-      @for (item of searchService.result; track searchService.trackByFn($index, item)) {
+      @for (item of searchService.result(); track searchService.trackByFn($index, item)) {
         <a class="search-result" [href]="item.path" (click)="toRoute($event, item)">
           @if (item.parent) {
             {{ item.parent.title }} &gt;
           }
-          <span [innerHtml]="searchText | highlight: item.title"></span>
+          <span [innerHtml]="searchText() | highlight: item.title"></span>
         </a>
       }
-      @if (hasSearchText && searchService.result.length === 0) {
+      @if (hasSearchText() && searchService.result().length === 0) {
         <dg-icon class="empty-icon" iconName="empty"></dg-icon>
       }
     </div>

--- a/packages/template/src/shared/search/search.component.spec.ts
+++ b/packages/template/src/shared/search/search.component.spec.ts
@@ -4,6 +4,11 @@ import { GlobalContext } from '../../services/global-context';
 import { SearchService } from '../../services/search.service';
 import { SearchComponent } from './search.component';
 
+const docItems = [
+    { id: 'intro', title: '介绍', path: 'guides/intro' },
+    { id: 'getting-started', title: 'Getting started', path: 'guides/intro/getting-started' },
+];
+
 describe('#search', () => {
     beforeEach(() => {
         vi.useFakeTimers({ advanceTimeDelta: 1, shouldAdvanceTime: true });
@@ -20,20 +25,7 @@ describe('#search', () => {
                 useValue: {
                     locale: 'zh-cn',
                     config: {},
-                },
-            },
-            {
-                provide: SearchService,
-                useValue: {
-                    hasAlgolia: false,
-                    result: [],
-                    initSearch: vi.fn().mockName('initSearch'),
-                    trackByFn: (
-                        index: number,
-                        item: {
-                            id: string;
-                        },
-                    ) => item.id || index,
+                    docItems,
                 },
             },
             {
@@ -57,11 +49,26 @@ describe('#search', () => {
         return spectator.query('.search-results-container') as HTMLElement;
     }
 
+    function resultIds() {
+        return spectator
+            .inject(SearchService)
+            .result()
+            .map((item) => item.id);
+    }
+
     it('should open results after typing', () => {
         spectator.focus('.search');
         spectator.typeInElement('intro', '.search');
         spectator.detectChanges();
         expect(getResultsContainer().classList.contains('is-searching')).toBe(true);
+    });
+
+    it('should filter results immediately for English input', () => {
+        spectator.focus('.search');
+        spectator.typeInElement('Getting', '.search');
+        spectator.detectChanges();
+        expect(resultIds()).toEqual(['getting-started']);
+        expect(getResultsContainer().querySelectorAll('.search-result').length).toBe(1);
     });
 
     it('should open results after IME compositionend (Enter to confirm)', () => {
@@ -72,9 +79,24 @@ describe('#search', () => {
         input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true, isComposing: true }));
         input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '介绍' }));
         spectator.detectChanges();
-        expect(spectator.component.searchText).toBe('介绍');
-        expect(spectator.component.hasSearchText).toBe(true);
+        expect(spectator.component.searchText()).toBe('介绍');
+        expect(spectator.component.hasSearchText()).toBe(true);
         expect(getResultsContainer().classList.contains('is-searching')).toBe(true);
+        expect(resultIds()).toEqual(['intro']);
+    });
+
+    it('should not search pinyin while IME is composing', () => {
+        spectator.focus('.search');
+        const input = getInput();
+        input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+        spectator.typeInElement('Getting', '.search');
+        spectator.detectChanges();
+        expect(resultIds()).toEqual([]);
+
+        input.value = '介绍';
+        input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '介绍' }));
+        spectator.detectChanges();
+        expect(resultIds()).toEqual(['intro']);
     });
 
     it('should keep results open when a trailing Enter is fired after compositionend', async () => {
@@ -97,7 +119,7 @@ describe('#search', () => {
         const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
         const prevented = !getResultsContainer().dispatchEvent(event);
         expect(prevented || event.defaultPrevented).toBe(true);
-        expect(spectator.component.searchText).toBe('介绍');
+        expect(spectator.component.searchText()).toBe('介绍');
         expect(getResultsContainer().classList.contains('is-searching')).toBe(true);
     });
 
@@ -107,8 +129,9 @@ describe('#search', () => {
         spectator.detectChanges();
         spectator.blur('.search');
         spectator.detectChanges();
-        expect(spectator.component.searchText).toBe('');
-        expect(spectator.component.isFocus).toBe(false);
+        expect(spectator.component.searchText()).toBe('');
+        expect(spectator.component.isFocus()).toBe(false);
+        expect(resultIds()).toEqual([]);
     });
 
     it('should clear search after selecting a result', () => {
@@ -123,8 +146,30 @@ describe('#search', () => {
         });
         spectator.detectChanges();
 
-        expect(spectator.component.searchText).toBe('');
-        expect(spectator.component.isFocus).toBe(false);
+        expect(spectator.component.searchText()).toBe('');
+        expect(spectator.component.isFocus()).toBe(false);
         expect(spectator.inject(Router).navigateByUrl).toHaveBeenCalledWith('/guides/intro');
+        expect(resultIds()).toEqual([]);
+        expect(getResultsContainer().classList.contains('is-searching')).toBe(false);
+    });
+
+    it('should reopen results when typing after selecting a result without refocusing', () => {
+        spectator.focus('.search');
+        spectator.typeInElement('介绍', '.search');
+        spectator.detectChanges();
+
+        spectator.component.toRoute(new Event('click'), {
+            id: 'intro',
+            title: '介绍',
+            path: '/guides/intro',
+        });
+        spectator.detectChanges();
+
+        spectator.typeInElement('Getting', '.search');
+        spectator.detectChanges();
+
+        expect(spectator.component.isFocus()).toBe(true);
+        expect(resultIds()).toEqual(['getting-started']);
+        expect(getResultsContainer().classList.contains('is-searching')).toBe(true);
     });
 });

--- a/packages/template/src/shared/search/search.component.ts
+++ b/packages/template/src/shared/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, AfterViewInit, OnDestroy, inject, ChangeDetectionStrategy, signal, computed, effect } from '@angular/core';
 import { Router } from '@angular/router';
 import { SearchPageInfo, SearchService } from '../../services/search.service';
 import { IconComponent } from '../icon/icon.component';
@@ -19,19 +19,27 @@ export class SearchComponent implements AfterViewInit, OnDestroy {
     searchService = inject(SearchService);
     private router = inject(Router);
 
-    searchText = '';
+    readonly searchText = signal('');
 
-    isFocus = false;
+    readonly isFocus = signal(false);
 
-    private composing = false;
+    private readonly composing = signal(false);
 
     /** Suppress a trailing Enter that some browsers emit right after compositionend. */
     private suppressEnter = false;
 
     private suppressEnterTimer: ReturnType<typeof setTimeout> | null = null;
 
-    get hasSearchText() {
-        return !!this.searchText?.trim();
+    readonly hasSearchText = computed(() => !!this.searchText().trim());
+
+    constructor() {
+        effect(() => {
+            const keywords = this.searchText();
+            if (this.composing() || this.searchService.hasAlgolia) {
+                return;
+            }
+            this.searchService.search(keywords);
+        });
     }
 
     ngAfterViewInit() {
@@ -43,24 +51,24 @@ export class SearchComponent implements AfterViewInit, OnDestroy {
     }
 
     focus() {
-        this.isFocus = true;
+        this.isFocus.set(true);
     }
 
     blur() {
-        if (this.composing) {
+        if (this.composing()) {
             return;
         }
         this.reset();
     }
 
     onCompositionStart() {
-        this.composing = true;
+        this.composing.set(true);
     }
 
     onCompositionEnd(event: CompositionEvent) {
-        this.searchText = (event.target as HTMLInputElement | null)?.value ?? '';
-        this.isFocus = true;
-        this.composing = false;
+        this.searchText.set((event.target as HTMLInputElement | null)?.value ?? '');
+        this.isFocus.set(true);
+        this.composing.set(false);
         // Firefox/Safari may emit a real Enter keydown after compositionend.
         this.suppressEnter = true;
         this.clearSuppressEnterTimer();
@@ -75,11 +83,11 @@ export class SearchComponent implements AfterViewInit, OnDestroy {
         if (event.key !== 'Enter') {
             return;
         }
-        if (this.composing || this.suppressEnter || event.isComposing || event.keyCode === IME_PROCESS_KEY_CODE) {
+        if (this.composing() || this.suppressEnter || event.isComposing || event.keyCode === IME_PROCESS_KEY_CODE) {
             return;
         }
         event.preventDefault();
-        this.isFocus = true;
+        this.isFocus.set(true);
     }
 
     toRoute($event: Event, item: SearchPageInfo) {
@@ -91,8 +99,8 @@ export class SearchComponent implements AfterViewInit, OnDestroy {
     }
 
     private reset() {
-        this.isFocus = false;
-        this.searchText = '';
+        this.isFocus.set(false);
+        this.searchText.set('');
     }
 
     private clearSuppressEnterTimer() {


### PR DESCRIPTION
## Summary
- Drive inner search from `searchText` signals so English typing updates results immediately under zoneless change detection.
- Skip searching while IME is composing, then match on the confirmed Chinese text after `compositionend`.
- Restore `isFocus` on input so the dropdown reopens after selecting a result and navigating.

## Test plan
- [ ] Type English keywords (e.g. `Getting`) and confirm only matching results appear without an extra click.
- [ ] Type Chinese with IME, confirm with Enter, and confirm the dropdown shows the matching docs.
- [ ] Click a result to navigate, then type again without clicking the search box; the dropdown should reopen.
- [ ] Blank or unmatched keywords show the empty state.


Made with [Cursor](https://cursor.com)